### PR TITLE
Move webview postMessage into confirm modal click handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,12 @@
     </div>
   </div>
 
-  <div id="position-modal" class="modal" tabindex="-1" role="dialog">
+  <div id="position-modal" class="modal" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title">Attention</h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <button id = "position-modal-cancel-button" type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
@@ -46,7 +46,7 @@
           <span id="position-modal-warning"></span>
         </div>
         <div class="modal-footer justify-content-center">
-          <button id="position-modal-close-button" type="button" class="btn btn-success">Confirm</button>
+          <button id="position-modal-confirm-button" type="button" class="btn btn-success">Confirm</button>
         </div>
       </div>
     </div>

--- a/js/robtarget.js
+++ b/js/robtarget.js
@@ -30,25 +30,44 @@ function variableRenameEvent_(event) {
     if (event.workspaceId == leftWorkspace.id){
       leftArmVariableRenamed = true; //true if triggered from the left workspace
       arm = "LEFT";
-      delete leftArmRobTargets[event.oldName];  //delete old variable name from rob targets array
+      delete leftArmRobTargets[event.oldName];  //delete old variable name from rob targets object
     } 
     else if (event.workspaceId == rightWorkspace.id){
       rightArmVariableRenamed = true; //true if triggered from the right workspace
       arm = "RIGHT";
-      delete rightArmRobTargets[event.oldName];  //delete old variable name from rob targets array
+      delete rightArmRobTargets[event.oldName];  //delete old variable name from rob targets object      
     } 
     
     newVariableName = event.newName;  //so get position function knows which variable to put target to
-    $('#position-modal').modal('show');
+
+    $('#position-modal').modal('show'); //show teach position modal
     var position_modal_warning = document.getElementById("position-modal-warning");
     position_modal_warning.innerHTML = `Please move <b>${arm}</b> arm to the desired position.`;
-    var position_modal_close_button = document.getElementById("position-modal-close-button");
-    position_modal_close_button.onclick = function(e) {
-      $('#position-modal').modal('hide');
-    };
-
-    window.chrome.webview.postMessage(`UPDATE_${arm}_ARM_POSITION`);
   }
+
+  /**
+   * Event listener for teach position modal cancel button
+   */
+  document.getElementById("position-modal-cancel-button").addEventListener("click", canceledModal);
+  function canceledModal() {
+    //clear everything
+    leftArmVariableRenamed = false;
+    rightArmVariableRenamed = false;
+    newVariableName = "";
+  };
+
+  /**
+   * Event listener for teach position modal confirm teach position button
+   */
+  document.getElementById("position-modal-confirm-button").addEventListener("click", confirmedModal);
+  function confirmedModal() {
+    var arm;
+    if (leftArmVariableRenamed) arm = "LEFT";
+    else if (rightArmVariableRenamed) arm = "RIGHT";     
+    $('#position-modal').modal('hide');
+    window.chrome.webview.postMessage(`UPDATE_${arm}_ARM_POSITION`);
+  };
+
 
   //register listener for message from host app and pass event to handler
   //receives a new robtarget for both arms from the host app when the Ok button is pressed


### PR DESCRIPTION
Robtargets were not being captured properly because the request arm position message had to be in the modal confirm click handler since it is asynchronous. Also added a handler for the cancel button on the modal and set the modal to static so that it cannot be hidden in any other way than the confirm or cancel buttons.